### PR TITLE
Feat/task by revisor

### DIFF
--- a/src/commons/infrastructure/schema.gql
+++ b/src/commons/infrastructure/schema.gql
@@ -139,6 +139,7 @@ type Query {
   findAllTasks: [Task!]!
   findTask(id: Int!): Task!
   findTasksByUser(userId: Int!): [Task!]!
+  findTasksByReviewer(revisorId: Int!): [Task!]!
   findAllCriticActivities: [CriticActivity!]!
   findCriticActivity(id: Float!): CriticActivity!
   findAllCriticActivitiesByTask(taskId: Float!): [CriticActivity!]!

--- a/src/task/application/task.service.ts
+++ b/src/task/application/task.service.ts
@@ -6,6 +6,7 @@ import { FindOneTaskUseCase } from './use_cases/find-one-task.use-case'
 import { UpdateTaskUseCase } from './use_cases/update-task.use-case'
 import { FindByUserIdTaskUseCase } from './use_cases/find-by-user-id-task.use-case'
 import { ITaskService, CreateTaskDTO, UpdateTaskDTO } from '@task/domain/interfaces/task.interface'
+import { FindByReviewerIdTaskUseCase } from './use_cases/find-by-reviewer-id-task.use-case'
 import { Task } from '@task/domain/task'
 
 @Injectable()
@@ -16,7 +17,8 @@ export class TaskService implements ITaskService {
     private readonly findAllTask: FindAllTaskUseCase,
     private readonly findOneTask: FindOneTaskUseCase,
     private readonly deleteTask: DeleteTaskUseCase,
-    private readonly findByUserIdTask: FindByUserIdTaskUseCase
+    private readonly findByUserIdTask: FindByUserIdTaskUseCase,
+    private readonly findByReviewerIdTask: FindByReviewerIdTaskUseCase
   ) {}
 
   create (dto: CreateTaskDTO): Promise<Task> {
@@ -41,5 +43,9 @@ export class TaskService implements ITaskService {
 
   findAllByUserId (userId: number): Promise<Task[]> {
     return this.findByUserIdTask.execute(userId)
+  }
+
+  findAllByReviewerId (revisorId: number): Promise<Task[]> {
+    return this.findByReviewerIdTask.execute(revisorId)
   }
 }

--- a/src/task/application/use_cases/find-by-reviewer-id-task.use-case.ts
+++ b/src/task/application/use_cases/find-by-reviewer-id-task.use-case.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common'
+import { ITaskStorageAdapter } from '@task/domain/interfaces/task.repository'
+import { Task } from '@task/domain/task'
+
+@Injectable()
+export class FindByReviewerIdTaskUseCase {
+  constructor (private readonly storage: ITaskStorageAdapter) {}
+
+  execute (revisorId: number): Promise<Task[]> {
+    return this.storage.findAllByReviewerId(revisorId)
+  }
+}

--- a/src/task/domain/interfaces/task.interface.ts
+++ b/src/task/domain/interfaces/task.interface.ts
@@ -24,4 +24,5 @@ export interface ITaskService {
   update(dto: UpdateTaskDTO): Promise<Task>;
   delete(id: number): Promise<boolean>;
   findAllByUserId(userId: number): Promise<Task[]>;
+  findAllByReviewerId(revisorId: number): Promise<Task[]>;
 }

--- a/src/task/domain/interfaces/task.repository.ts
+++ b/src/task/domain/interfaces/task.repository.ts
@@ -7,5 +7,5 @@ export abstract class ITaskStorageAdapter {
   abstract update (task: Task): Promise<Task>
   abstract delete (id: number): Promise<boolean>
   abstract findAllByUserId (userId: number): Promise<Task[]>
-  abstract findAllByReviewerId(revisorId: number): Promise<Task[]>
+  abstract findAllByReviewerId (revisorId: number): Promise<Task[]>
 }

--- a/src/task/domain/interfaces/task.repository.ts
+++ b/src/task/domain/interfaces/task.repository.ts
@@ -7,4 +7,5 @@ export abstract class ITaskStorageAdapter {
   abstract update (task: Task): Promise<Task>
   abstract delete (id: number): Promise<boolean>
   abstract findAllByUserId (userId: number): Promise<Task[]>
+  abstract findAllByReviewerId(revisorId: number): Promise<Task[]>
 }

--- a/src/task/infrastructure/adapters/apollo/resolvers/task.resolver.ts
+++ b/src/task/infrastructure/adapters/apollo/resolvers/task.resolver.ts
@@ -49,4 +49,8 @@ export class TaskResolver {
     return this.taskService.findAllByUserId(userId)
   }
 
+  @Query(() => [Task])
+  findTasksByReviewer (@Args('revisorId', { type: () => Int }) revisorId: number) {
+    return this.taskService.findAllByReviewerId(revisorId)
+  }
 }

--- a/src/task/infrastructure/adapters/prisma/task.storage.ts
+++ b/src/task/infrastructure/adapters/prisma/task.storage.ts
@@ -30,4 +30,9 @@ export class TaskStorage {
     return this.prisma.task.findMany({ where: { creatorUserId: userId } })
   }
 
+  async findAllByReviewerId (revisorId: number): Promise<Task[]> {
+    return this.prisma.task.findMany({
+      where: { revisorUserId: revisorId }
+    })
+  }
 }

--- a/src/task/infrastructure/adapters/repository/task-prisma.repository.ts
+++ b/src/task/infrastructure/adapters/repository/task-prisma.repository.ts
@@ -60,4 +60,8 @@ export class TaskStorageAdapter implements ITaskStorageAdapter {
     return result.map(mapPrismaTaskToDomain)
   }
 
+  async findAllByReviewerId (revisorId: number): Promise<Task[]> {
+    const tasks = await this.storage.findAllByReviewerId(revisorId)
+    return tasks.map(mapPrismaTaskToDomain)
+  }
 }

--- a/src/task/infrastructure/task.module.ts
+++ b/src/task/infrastructure/task.module.ts
@@ -13,6 +13,7 @@ import { DeleteTaskUseCase } from '@task/application/use_cases/delete-task.use-c
 import { FindAllTaskUseCase } from '@task/application/use_cases/find-all-task.use-case'
 import { FindOneTaskUseCase } from '@task/application/use_cases/find-one-task.use-case'
 import { FindByUserIdTaskUseCase } from '@task/application/use_cases/find-by-user-id-task.use-case'
+import { FindByReviewerIdTaskUseCase } from '@task/application/use_cases/find-by-reviewer-id-task.use-case'
 
 @Module({
   imports: [CommonsModule],
@@ -27,6 +28,7 @@ import { FindByUserIdTaskUseCase } from '@task/application/use_cases/find-by-use
     FindAllTaskUseCase,
     FindOneTaskUseCase,
     FindByUserIdTaskUseCase,
+    FindByReviewerIdTaskUseCase,
 
     {
       provide: 'ITaskService',


### PR DESCRIPTION
Se agregó la query para obtener las tareas según el usuario revisor. Para comprobar que funcione, correr el backend, y en graphql probar la siguiente query:
query FindTasksByReviewer($revisorId: Int!) {
  findTasksByReviewer(revisorId: $revisorId) {
    id
    title
    instruction
    state
    creatorUserId
    revisorUserId
    assignationDate
    requiredSendDate
    comments
    changeHistory
  }
}
con la siguiente variable:
{
  "revisorId": 3
}
En este caso, para comprobar que todo esté bien, asegurarse antes que el usuario exista y tenga asignada al menos una tarea.